### PR TITLE
Adding XHR mock support for GraphQL requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Library (written in TypeScript) to mock REST and GraphQL requests
 - [Examples](#examples)
   - [Basic mock injection without scenarios](#basic-mock-injection-without-scenarios)
   - [Mock injection with scenarios](#mock-injection-with-scenarios)
-  - [Basic GraphQL mock injection (Fetch)](#basic-graphql-mock-injection-fetch)
+  - [Basic GraphQL mock injection](#basic-graphql-mock-injection)
 - [Exported types](#exported-types)
   - [Scenarios](#scenarios)
   - [HttpMock](#httpmock)
@@ -263,7 +263,7 @@ axios
 
 In this example, if we load our site up with `?scenario=failedLogin` in the querystring and then attempt to hit the `login` endpoint, it will fail with a 401. However, the `some-other-endpoint` endpoint will still respond with the response in the `default` scenario as we have not provided one in the `failedLogin` scenario.
 
-### Basic GraphQL mock injection (Fetch)
+### Basic GraphQL mock injection
 
 Here, we have a React application using `urql` as a GraphQL client. This shows how GraphQL queries work and it can be assumed that if you want to use REST mocks in this application, you can do so as you normally would (see examples above).
 
@@ -373,5 +373,4 @@ Union type of [`HttpMock`](#HttpMock) and [`GraphQLMock`](#GraphQLMock).
 
 ## Gotchas
 
-- GraphQL mocks only work with clients that use Fetch. XHR is currently not supported for this.
 - GraphQL operations must have an operation name.

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -389,6 +389,38 @@ describe('data-mocks', () => {
       const result = reduceAllMocksForScenario(scenarios, 'scenario');
       expect(result).toEqual([]);
     });
+
+    test(`Preserves any flags defined in the url regex`, () => {
+      const scenarios: Scenarios = {
+        default: [],
+        scenario: [
+          {
+            url: /^\/foo/i,
+            method: 'GET',
+            response: {},
+            responseCode: 200,
+          },
+          {
+            url: /^\/graphql/i,
+            method: 'GRAPHQL',
+            operations: [
+              {
+                operationName: 'Query',
+                type: 'query',
+                response: { data: { test: 'data' } },
+              },
+            ],
+          },
+        ],
+      };
+      expect('/Foo').toMatch(scenarios.scenario[0].url);
+      expect('/GraphQL').toMatch(scenarios.scenario[1].url);
+
+      const result = reduceAllMocksForScenario(scenarios, 'scenario');
+      expect(result).toHaveLength(2);
+      expect('/Foo').toMatch(result[0].url);
+      expect('/GraphQL').toMatch(result[1].url);
+    });
   });
 
   describe('Utility: extractScenarioFromLocation', () => {

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -209,14 +209,16 @@ describe('data-mocks', () => {
           method: 'GRAPHQL',
           operations: [
             {
-              operationName: 'Query',
+              operationName: 'QueryTest',
               type: 'query',
-              response: { data: { test: 'test' } },
+              response: { data: { test: 'query test' } },
+              responseHeaders: { token: 'foo' },
             },
             {
-              operationName: 'Mutation',
+              operationName: 'MutationTest',
               type: 'mutation',
-              response: { data: { test: 'test' } },
+              response: { data: { test: 'mutation test' } },
+              responseHeaders: { token: 'bar' },
             },
           ],
         },
@@ -227,11 +229,55 @@ describe('data-mocks', () => {
       injectMocks(scenarios, 'default');
     });
 
-    test(`Correct endpoints being called for mocked graphQL endpoints`, async () => {
-      expect(fetchMock.calls().length).toEqual(0);
+    describe('Fetch', () => {
+      test(`Correct endpoints being called for mocked graphQL endpoints`, async () => {
+        expect(fetchMock.calls().length).toEqual(0);
 
-      await fetch('https://www.test.com/graphql', { method: 'GET' });
-      expect(fetchMock.called(graphQLMatcher)).toBeTruthy();
+        await fetch('https://www.test.com/graphql', { method: 'GET' });
+        expect(fetchMock.called(graphQLMatcher)).toBeTruthy();
+      });
+
+      test('Correct response when using GET request', async () => {
+        const response = await fetch(
+          'https://www.test.com/graphql?query={}&operationName=QueryTest',
+          { method: 'GET' }
+        );
+        const responseBody = await response.json();
+        expect(responseBody.data).toEqual({ test: 'query test' });
+        expect(response.headers.get('token')).toEqual('foo');
+      });
+
+      test('Correct response when using POST request', async () => {
+        const response = await fetch('https://www.test.com/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query: '{}', operationName: 'MutationTest' }),
+        });
+        const responseBody = await response.json();
+        expect(responseBody.data).toEqual({ test: 'mutation test' });
+        expect(response.headers.get('token')).toEqual('bar');
+      });
+    });
+
+    describe('XHR', () => {
+      test('Correct response when using GET request', async () => {
+        const { data, headers } = await axios.get(
+          'https://www.test.com/graphql?query={}&operationName=QueryTest'
+        );
+        expect(data.data).toEqual({ test: 'query test' });
+        expect(headers).toEqual({ token: 'foo' });
+      });
+
+      test('Correct response when using POST request', async () => {
+        const { data, headers } = await axios.post(
+          'https://www.test.com/graphql',
+          {
+            query: '{}',
+            operationName: 'MutationTest',
+          }
+        );
+        expect(data.data).toEqual({ test: 'mutation test' });
+        expect(headers).toEqual({ token: 'bar' });
+      });
     });
   });
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -190,17 +190,12 @@ function handleRestMock({
  */
 function handleGraphQLMock({ url, operations }: GraphQLMock) {
   const graphQLErrorResponse = { errors: [] };
-  const findMockGet = (u: string) => {
-    const parsedUrl = new URL(u);
-    const operationName = parsedUrl.searchParams.get('operationName');
-    return operations.find((o) => o.operationName === operationName);
-  };
-  const findMockPost = (postBody) => {
+  const findOperation = (operationName: string) =>
+    operations.find((o) => o.operationName === operationName);
+  const findOperationPost = (postBody) => {
     const jsonBody =
       typeof postBody === 'string' ? JSON.parse(postBody) : postBody;
-    return operations.find(
-      ({ operationName }) => operationName === jsonBody.operationName
-    );
+    return findOperation(jsonBody.operationName);
   };
   const delayedResponse = (
     delay: number | undefined,
@@ -210,42 +205,77 @@ function handleGraphQLMock({ url, operations }: GraphQLMock) {
   };
 
   fetchMock.get(url, (u) => {
-    const mock = findMockGet(u);
+    const parsedUrl = new URL(u);
+    const operationName = parsedUrl.searchParams.get('operationName') || '';
+    const operation = findOperation(operationName);
 
-    if (!mock || mock?.type === 'mutation') {
+    if (!operation || operation?.type === 'mutation') {
       return graphQLErrorResponse;
     }
 
     const finalResponse = {
-      body: mock.response,
-      status: mock.responseCode,
-      headers: mock.responseHeaders,
+      body: operation.response,
+      status: operation.responseCode,
+      headers: operation.responseHeaders,
     };
 
-    return delayedResponse(mock.delay, finalResponse);
+    return delayedResponse(operation.delay, finalResponse);
   });
 
   fetchMock.post(
     url,
     (_, { body }) => {
-      const mock = findMockPost(body);
+      const operation = findOperationPost(body);
 
-      if (!mock) {
+      if (!operation) {
         return graphQLErrorResponse;
       }
 
       const finalResponse = {
-        body: mock.response,
-        status: mock.responseCode,
-        headers: mock.responseHeaders,
+        body: operation.response,
+        status: operation.responseCode,
+        headers: operation.responseHeaders,
       };
 
-      return delayedResponse(mock.delay, finalResponse);
+      return delayedResponse(operation.delay, finalResponse);
     },
     {
       overwriteRoutes: false,
     }
   );
+
+  XHRMock.get(url, (req, res) => {
+    const operationName = req.url().query?.operationName || '';
+    const operation = findOperation(operationName);
+
+    if (!operation || operation?.type === 'mutation') {
+      return res.body(graphQLErrorResponse);
+    }
+
+    const { response, responseCode, responseHeaders, delay } = operation;
+    if (responseHeaders) {
+      res.headers(responseHeaders);
+    }
+    return addDelay(delay ? delay : 0).then(() => {
+      return res.status(responseCode ?? 200).body(response);
+    });
+  });
+
+  XHRMock.post(url, (req, res) => {
+    const operation = findOperationPost(req.body());
+
+    if (!operation) {
+      return res.body(graphQLErrorResponse);
+    }
+
+    const { response, responseCode, responseHeaders, delay } = operation;
+    if (responseHeaders) {
+      res.headers(responseHeaders);
+    }
+    return addDelay(delay ? delay : 0).then(() =>
+      res.status(responseCode ?? 200).body(response)
+    );
+  });
 }
 
 /**


### PR DESCRIPTION
- Adding XHR mock support for GraphQL requests.
- Fix issue where GraphQL url regex was altered when scenario set.
- Update README to remove references to fetch only GraphQL support.